### PR TITLE
Skip invalid `mid` in `Sweeper::clearMultis`

### DIFF
--- a/src/spatialjoin/Sweeper.cpp
+++ b/src/spatialjoin/Sweeper.cpp
@@ -431,7 +431,7 @@ void Sweeper::multiOut(size_t t, const std::string& gidA) {
 void Sweeper::flush() {
   LOG(INFO) << _multiIds.size() << " multi geometries";
   for (size_t i = 0; i < _multiIds.size(); i++) {
-    diskAdd({i, 2, 1, _multiLeftX[i] - 1, false, POINT, 0.0, {}});
+    diskAdd({i, 1, 0, _multiLeftX[i] - 1, false, POINT, 0.0, {}});
   }
 
   ssize_t r = write(_file, _outBuffer, _obufpos);
@@ -525,7 +525,7 @@ void Sweeper::sweep() {
       auto cur = reinterpret_cast<const BoxVal*>(buf + i);
       jj++;
 
-      if (!cur->out && cur->loY > cur->upY) {
+      if (!cur->out && cur->loY == 1 && cur->upY == 0 && cur->type == POINT) {
         // special multi-IN
         _activeMultis.insert(cur->id);
       } else if (!cur->out) {


### PR DESCRIPTION
Not sure if this is an appropriate fix, but spatialjoin then runs through without errors and the results look reasonable.