### PR TITLE
Add config option to enforce a two-sided join

### DIFF
--- a/src/spatialjoin/SpatialJoinMain.cpp
+++ b/src/spatialjoin/SpatialJoinMain.cpp
@@ -335,6 +335,7 @@ int main(int argc, char** argv) {
                             noGeometryChecks,
                             withinDist,
                             computeDE9IM,
+                            false,
                             writeRelCb,
                             {},
                             {},

--- a/src/spatialjoin/SpatialJoinMain.cpp
+++ b/src/spatialjoin/SpatialJoinMain.cpp
@@ -335,7 +335,7 @@ int main(int argc, char** argv) {
                             noGeometryChecks,
                             withinDist,
                             computeDE9IM,
-                            false,
+                            inputFiles.size() == 2,
                             writeRelCb,
                             {},
                             {},

--- a/src/spatialjoin/Sweeper.h
+++ b/src/spatialjoin/Sweeper.h
@@ -202,6 +202,7 @@ struct SweeperCfg {
   bool noGeometryChecks;
   double withinDist;
   bool computeDE9IM;
+  bool forceTwoSided;
   std::function<void(size_t t, const char* a, size_t an, const char* b,
                      size_t bn, const char* pred, size_t predn)>
       writeRelCb;
@@ -268,6 +269,8 @@ class Sweeper {
     // OUTFACTOR 1
 
     _outBuffer = new unsigned char[BUFFER_S];
+
+    if (_cfg.forceTwoSided) _numSides = 2;
   };
 
   ~Sweeper() { close(_file); }

--- a/src/spatialjoin/tests/TestMain.cpp
+++ b/src/spatialjoin/tests/TestMain.cpp
@@ -82,56 +82,64 @@ int main(int, char**) {
       " contains ", " covers ",  " touches ", " equals ", " overlaps ",
       " crosses ",  false,       false,       false,      false,
       false,        false,       false,       -1,         false,
-      {},           {},          {},          {},         {}};
+      false,        {},          {},          {},         {},
+      {}};
 
   sj::SweeperCfg all{
       NUM_THREADS,  NUM_THREADS, 1000,        1000,       " intersects ",
       " contains ", " covers ",  " touches ", " equals ", " overlaps ",
       " crosses ",  true,        true,        true,       true,
       true,         true,        false,       -1,         false,
-      {},           {},          {},          {},         {}};
+      false,        {},          {},          {},         {},
+      {}};
 
   sj::SweeperCfg noSurfaceArea{
       NUM_THREADS,  NUM_THREADS, 1000,        1000,       " intersects ",
       " contains ", " covers ",  " touches ", " equals ", " overlaps ",
       " crosses ",  true,        false,       true,       true,
       true,         true,        false,       -1,         false,
-      {},           {},          {},          {},         {}};
+      false,        {},          {},          {},         {},
+      {}};
 
   sj::SweeperCfg noBoxIds{
       NUM_THREADS,  NUM_THREADS, 1000,        1000,       " intersects ",
       " contains ", " covers ",  " touches ", " equals ", " overlaps ",
       " crosses ",  false,       true,        true,       true,
       true,         true,        false,       -1,         false,
-      {},           {},          {},          {},         {}};
+      false,        {},          {},          {},         {},
+      {}};
 
   sj::SweeperCfg noObb{
       NUM_THREADS,  NUM_THREADS, 1000,        1000,       " intersects ",
       " contains ", " covers ",  " touches ", " equals ", " overlaps ",
       " crosses ",  true,        true,        false,      true,
       true,         true,        false,       -1,         false,
-      {},           {},          {},          {},         {}};
+      false,        {},          {},          {},         {},
+      {}};
 
   sj::SweeperCfg noDiagBox{
       NUM_THREADS,  NUM_THREADS, 1000,        1000,       " intersects ",
       " contains ", " covers ",  " touches ", " equals ", " overlaps ",
       " crosses ",  true,        true,        true,       false,
       true,         true,        false,       -1,         false,
-      {},           {},          {},          {},         {}};
+      false,        {},          {},          {},         {},
+      {}};
 
   sj::SweeperCfg noFastSweep{
       NUM_THREADS,  NUM_THREADS, 1000,        1000,       " intersects ",
       " contains ", " covers ",  " touches ", " equals ", " overlaps ",
       " crosses ",  true,        true,        true,       true,
       false,        true,        false,       -1,         false,
-      {},           {},          {},          {},         {}};
+      false,        {},          {},          {},         {},
+      {}};
 
   sj::SweeperCfg noInnerOuter{
       NUM_THREADS,  NUM_THREADS, 1000,        1000,       " intersects ",
       " contains ", " covers ",  " touches ", " equals ", " overlaps ",
       " crosses ",  true,        true,        true,       true,
       true,         false,       false,       -1,         false,
-      {},           {},          {},          {},         {}};
+      false,        {},          {},          {},         {},
+      {}};
 
   std::vector<sj::SweeperCfg> cfgs{baseline,    all,         noSurfaceArea,
                                    noBoxIds,    noObb,       noDiagBox,


### PR DESCRIPTION
The semantics that a two-sided join is automatically detected once we have seen geometries from two different sides breaks if one of the sides is empty. A self-join is done in this case, which will result in problems if the caller relies on a two-sided join. This behavior has been the source of  multiple bugs in Qlever such as <https://github.com/ad-freiburg/qlever/pull/3068>. With this change, we can now specify that we always want two-sided join in `SweeperCfg`. 