### PR TITLE
Adjusted to new projection sigunature in util

### DIFF
--- a/src/spatialjoin/WKTParse.h
+++ b/src/spatialjoin/WKTParse.h
@@ -140,6 +140,8 @@ class WKTParserBase {
       c = idp + 1;
     }
 
+    auto crsType = getCRSType(c, &c);
+
     if (lastC - c > 2 && *c == '<') {
       // handle reference geometries
       const char *end = strchr(c, ',');
@@ -172,9 +174,9 @@ class WKTParserBase {
         c = end + 1;
       } while (c < lastC && ((end = strchr(c, ',')) || (end = strchr(c, '>'))));
     } else {
-      auto crsType = getCRSType(c, &c);
       // erroneous line / crs type, ignore
       if (crsType == util::geo::CRSType::UNSUPPORTED) return; 
+
       auto wktType = getWKTType(c, &c);
       if (wktType == util::geo::WKTType::POINT) {
         const auto &point = pointFromWKTProj<int32_t>(c, 0, &projFunc, crsType);

--- a/src/spatialjoin/WKTParse.h
+++ b/src/spatialjoin/WKTParse.h
@@ -104,8 +104,8 @@ class WKTParserBase {
     }
   };
 
-  static util::geo::I32Point projFunc(const util::geo::DPoint &p) {
-    auto projPoint = latLngToWebMerc(p);
+  static util::geo::I32Point projFunc(const util::geo::DPoint &p, util::geo::CRSType sourceCRS) {
+    auto projPoint = projectToWebMerc(p, sourceCRS);
     return {static_cast<int>(projPoint.getX() * PREC),
             static_cast<int>(projPoint.getY() * PREC)};
   }
@@ -172,38 +172,39 @@ class WKTParserBase {
         c = end + 1;
       } while (c < lastC && ((end = strchr(c, ',')) || (end = strchr(c, '>'))));
     } else {
+      auto crsType = getCRSType(c, &c);
       auto wktType = getWKTType(c, &c);
       if (wktType == util::geo::WKTType::POINT) {
-        const auto &point = pointFromWKTProj<int32_t>(c, 0, &projFunc);
+        const auto &point = pointFromWKTProj<int32_t>(c, 0, &projFunc, crsType);
         _bboxes[t] = util::geo::extendBox(_sweeper->add(point, id, side, batch),
                                           _bboxes[t]);
       } else if (wktType == util::geo::WKTType::MULTIPOINT) {
-        const auto &mp = multiPointFromWKTProj<int32_t>(c, 0, &projFunc);
+        const auto &mp = multiPointFromWKTProj<int32_t>(c, 0, &projFunc, crsType);
         if (mp.size() != 0)
           _bboxes[t] = util::geo::extendBox(_sweeper->add(mp, id, side, batch),
                                             _bboxes[t]);
       } else if (wktType == util::geo::WKTType::LINESTRING) {
-        const auto &line = lineFromWKTProj<int32_t>(c, 0, &projFunc);
+        const auto &line = lineFromWKTProj<int32_t>(c, 0, &projFunc, crsType);
         if (line.size() > 1)
           _bboxes[t] = util::geo::extendBox(
               _sweeper->add(line, id, side, batch), _bboxes[t]);
       } else if (wktType == util::geo::WKTType::MULTILINESTRING) {
-        const auto &ml = multiLineFromWKTProj<int32_t>(c, 0, &projFunc);
+        const auto &ml = multiLineFromWKTProj<int32_t>(c, 0, &projFunc, crsType);
         _bboxes[t] = util::geo::extendBox(_sweeper->add(ml, id, side, batch),
                                           _bboxes[t]);
       } else if (wktType == util::geo::WKTType::POLYGON) {
-        const auto &poly = polygonFromWKTProj<int32_t>(c, 0, &projFunc);
+        const auto &poly = polygonFromWKTProj<int32_t>(c, 0, &projFunc, crsType);
         if (poly.getOuter().size() > 1)
           _bboxes[t] = util::geo::extendBox(
               _sweeper->add(poly, id, side, batch), _bboxes[t]);
       } else if (wktType == util::geo::WKTType::MULTIPOLYGON) {
-        const auto &mp = multiPolygonFromWKTProj<int32_t>(c, 0, &projFunc);
+        const auto &mp = multiPolygonFromWKTProj<int32_t>(c, 0, &projFunc, crsType);
         if (mp.size())
           _bboxes[t] = util::geo::extendBox(_sweeper->add(mp, id, side, batch),
                                             _bboxes[t]);
       } else if (wktType == util::geo::WKTType::COLLECTION) {
 
-        const auto &col = collectionFromWKTProj<int32_t>(c, 0, &projFunc);
+        const auto &col = collectionFromWKTProj<int32_t>(c, 0, &projFunc, crsType);
 
         size_t numGeoms = 0;
         for (const auto &a : col) {

--- a/src/spatialjoin/WKTParse.h
+++ b/src/spatialjoin/WKTParse.h
@@ -173,6 +173,8 @@ class WKTParserBase {
       } while (c < lastC && ((end = strchr(c, ',')) || (end = strchr(c, '>'))));
     } else {
       auto crsType = getCRSType(c, &c);
+      // erroneous line / crs type, ignore
+      if (crsType == util::geo::CRSType::UNSUPPORTED) return; 
       auto wktType = getWKTType(c, &c);
       if (wktType == util::geo::WKTType::POINT) {
         const auto &point = pointFromWKTProj<int32_t>(c, 0, &projFunc, crsType);

--- a/src/spatialjoin/tests/TestMain.cpp
+++ b/src/spatialjoin/tests/TestMain.cpp
@@ -943,6 +943,90 @@ int main(int, char**) {
     }
 
     {
+      // As with references just with different CRS IRIs for the geometries.
+      RunStats stats;
+      auto res = fullRun(TEST_DATASET_DIR "/crs_iris", cfg, &stats);
+
+      TEST(res.find("$RefA crosses TestC$") != std::string::npos);
+      TEST(res.find("$TestC crosses RefA$") != std::string::npos);
+      TEST(res.find("$TestA crosses RefA$") == std::string::npos);
+      TEST(res.find("$TestA crosses TestB$") != std::string::npos);
+      TEST(res.find("$TestB crosses TestA$") != std::string::npos);
+      TEST(res.find("$RefA crosses TestA$") == std::string::npos);
+      TEST(res.find("$RefA crosses TestB$") == std::string::npos);
+      TEST(res.find("$RefA intersects TestB$") != std::string::npos);
+      TEST(res.find("$TestB intersects RefA$") != std::string::npos);
+      TEST(res.find("$RefA intersects TestA$") != std::string::npos);
+      TEST(res.find("$TestA intersects RefA$") != std::string::npos);
+      TEST(res.find("$RefA covers TestA$") != std::string::npos);
+      TEST(res.find("$RefA covers TestB$") != std::string::npos);
+      TEST(res.find("$RefA covers TestC$") == std::string::npos);
+      TEST(res.find("$RefB equals TestA$") != std::string::npos);
+      TEST(res.find("$TestA equals RefB$") != std::string::npos);
+      TEST(res.find("$<> equals RefG$") != std::string::npos);
+      TEST(res.find("$RefG equals <>$") != std::string::npos);
+      TEST(res.find("$RefG equals RefJ$") != std::string::npos);
+      TEST(res.find("$<> equals RefJ$") != std::string::npos);
+      TEST(res.find("$RefJ equals RefG$") != std::string::npos);
+      TEST(res.find("$RefJ equals <>$") != std::string::npos);
+      TEST(res.find("$TestD1 equals TestD2$") != std::string::npos);
+      TEST(res.find("$TestD2 equals TestD1$") != std::string::npos);
+      TEST(res.find("$TestD1 intersects TestD2$") != std::string::npos);
+      TEST(res.find("$TestD2 intersects TestD1$") != std::string::npos);
+      TEST(res.find("$TestD1 covers TestD2$") != std::string::npos);
+      TEST(res.find("$TestD1 contains TestD2$") != std::string::npos);
+      TEST(res.find("$TestD2 covers TestD1$") != std::string::npos);
+      TEST(res.find("$TestD2 contains TestD1$") != std::string::npos);
+      TEST(res.find("$TestD3 covers TestD2$") != std::string::npos);
+      TEST(res.find("$TestD3 contains TestD2$") != std::string::npos);
+      TEST(res.find("$TestD3 covers TestD1$") != std::string::npos);
+      TEST(res.find("$TestD3 contains TestD1$") != std::string::npos);
+      TEST(res.find("$TestD1 intersects TestD3$") != std::string::npos);
+      TEST(res.find("$TestD2 intersects TestD3$") != std::string::npos);
+      TEST(res.find("$TestD3 intersects TestD1$") != std::string::npos);
+      TEST(res.find("$TestD3 intersects TestD2$") != std::string::npos);
+
+      TEST(res.find("$TestP1 touches TestD1$") != std::string::npos);
+      TEST(res.find("$TestP1 touches TestD2$") != std::string::npos);
+      TEST(res.find("$TestP1 touches TestD3$") != std::string::npos);
+      TEST(res.find("$TestP1 touches TestD4$") != std::string::npos);
+      TEST(res.find("$TestD1 touches TestP1$") != std::string::npos);
+      TEST(res.find("$TestD2 touches TestP1$") != std::string::npos);
+      TEST(res.find("$TestD3 touches TestP1$") != std::string::npos);
+      TEST(res.find("$TestD4 touches TestP1$") != std::string::npos);
+
+      TEST(res.find("$TestP2 touches TestD1$") != std::string::npos);
+      TEST(res.find("$TestP2 touches TestD2$") != std::string::npos);
+      TEST(res.find("$TestP2 touches TestD3$") != std::string::npos);
+      TEST(res.find("$TestP2 touches TestD4$") != std::string::npos);
+      TEST(res.find("$TestD1 touches TestP2$") != std::string::npos);
+      TEST(res.find("$TestD2 touches TestP2$") != std::string::npos);
+      TEST(res.find("$TestD3 touches TestP2$") != std::string::npos);
+      TEST(res.find("$TestD4 touches TestP2$") != std::string::npos);
+
+      TEST(res.find("$TestP1 intersects TestD1$") != std::string::npos);
+      TEST(res.find("$TestP1 intersects TestD2$") != std::string::npos);
+      TEST(res.find("$TestP1 intersects TestD3$") != std::string::npos);
+      TEST(res.find("$TestP1 intersects TestD4$") != std::string::npos);
+      TEST(res.find("$TestD1 intersects TestP1$") != std::string::npos);
+      TEST(res.find("$TestD2 intersects TestP1$") != std::string::npos);
+      TEST(res.find("$TestD3 intersects TestP1$") != std::string::npos);
+      TEST(res.find("$TestD4 intersects TestP1$") != std::string::npos);
+
+      TEST(res.find("$TestP2 intersects TestD1$") != std::string::npos);
+      TEST(res.find("$TestP2 intersects TestD2$") != std::string::npos);
+      TEST(res.find("$TestP2 intersects TestD3$") != std::string::npos);
+      TEST(res.find("$TestP2 intersects TestD4$") != std::string::npos);
+      TEST(res.find("$TestD1 intersects TestP2$") != std::string::npos);
+      TEST(res.find("$TestD2 intersects TestP2$") != std::string::npos);
+      TEST(res.find("$TestD3 intersects TestP2$") != std::string::npos);
+      TEST(res.find("$TestD4 intersects TestP2$") != std::string::npos);
+
+      TEST(res.find("$unsupported$") == std::string::npos);
+      TEST(res.find("$unsupported2$") == std::string::npos);
+    }
+
+    {
       RunStats stats;
       auto res = fullRun(TEST_DATASET_DIR "/bawue", cfg, &stats);
       TEST(stats.numReferences, ==, 1);

--- a/src/spatialjoin/tests/datasets/crs_iris
+++ b/src/spatialjoin/tests/datasets/crs_iris
@@ -1,0 +1,24 @@
+TestA	<http://www.opengis.net/def/crs/OGC/1.3/CRS84> LINESTRING(20 20, 30 30)
+TestB	<http://www.opengis.net/def/crs/EPSG/0/4326> LINESTRING(20 30, 30 20)
+TestC	<http://www.opengis.net/def/crs/EPSG/0/3857> LINESTRING(2226389.8158654715 2875744.624352243, 2782987.269831839 2273030.9269876895)
+<>	<http://www.opengis.net/def/crs/OGC/1.3/CRS84> POINT(1, 1)
+RefA	<TestA,TestB>
+RefB	<TestA>
+RefC	<TestA, TestB>
+RefD	<TestA, TestB,>
+RefE	<,>
+RefF	<>
+RefG	<<>>
+RefH
+RefI	
+RefJ	<RefG>
+TestP1	<http://www.opengis.net/def/crs/EPSG/0/4326> POINT(20 20)
+TestP2	<TestP1>
+TestD1	<http://www.opengis.net/def/crs/OGC/1.3/CRS84> POLYGON((20 20, 25 20, 25 25, 20 20))
+TestD2	<http://www.opengis.net/def/crs/EPSG/0/4326> POLYGON((20 20, 20 25, 25 25,20 20))
+TestD3	<http://www.opengis.net/def/crs/OGC/1.3/CRS84> MULTIPOLYGON(((1 1, 2 2, 3 3, 1 1)), ((20 20, 25 20, 25 25,20 20)))
+TestD5	<http://www.opengis.net/def/crs/EPSG/0/4326> MULTIPOLYGON(((1 1, 2 2, 3 3, 1 1)), ((20 20, 20 25, 25 25,20 20)))
+Point	<http://www.opengis.net/def/crs/EPSG/0/3857> POINT(2337709.3066587453 2391878.5879443143)
+TestD4	<http://www.opengis.net/def/crs/OGC/1.3/CRS84> MULTIPOLYGON(((1 1, 2 2, 3 3, 1 1)), ((20 20, 25 20, 25 25,20 20)))
+unsupported	<http://www.opengis.net/def/crs/EPSG/0/3035> POINT(5405991.849200747 -229955.78905992862)
+unsupported2	<http://www.opengis.net/def/crs/EPSG/0/3035> LINESTRING(5405991.849200747 -229955.78905992862, 6473391.208769935 -31544.571863594465)


### PR DESCRIPTION
This adds a `sourceCRS` argument to the used `projFunc`, as required by the new projection function signature from [util CRS PR](https://github.com/ad-freiburg/util/pull/5). This will only work in combination with the changes from the linked PR.